### PR TITLE
Add cross-device settings sync via Chrome Storage Sync API

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,7 +4,8 @@ if (typeof importScripts === "function") importScripts("defaults.js", "providers
 
 chrome.storage.local.get(null).then(createContextMenus);
 chrome.storage.onChanged.addListener(handleStorageChanges);
-restoreProvidersFromSync();
+// Catch up on snapshots that synced in while the service worker was asleep
+restoreOptionsFromSync();
 chrome.contextMenus.onClicked.addListener(handleContextMenuClicked);
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
@@ -30,16 +31,19 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 const PROMPT_ID_PREFIX = "custom-prompt";
 
 chrome.runtime.onInstalled.addListener((details) => {
-  if (details.reason === "install") {
+  if (details.reason !== "install") return;
+  // If this browser profile already has synced settings from another machine,
+  // adopt them instead of seeding defaults — the user shouldn't have to set
+  // anything up again. (If Chrome hasn't downloaded the sync data yet, defaults
+  // are seeded now and the snapshot is adopted when it arrives, because its
+  // savedAt will be newer than this machine's.)
+  restoreOptionsFromSync({ force: true }).then((restored) => {
+    if (restored) return;
     const settings = new Options();
-
     makeDefaultPrompts().forEach(p => settings.promptData.push(p));
-
     settings.defaultPopupStyle = DEFAULT_POPUP_STYLE;
-    // Restore synced provider keys AFTER the defaults are written, otherwise the
-    // empty providers object in `settings` would clobber a restore that ran first.
-    chrome.storage.local.set(settings).then(restoreProvidersFromSync);
-  }
+    chrome.storage.local.set(settings);
+  });
 });
 
 // ── Context menu ──────────────────────────────────────────────────────────────
@@ -62,50 +66,13 @@ function handleStorageChanges(changes, area) {
   if (area === "local" && "promptData" in changes) {
     chrome.storage.local.get(null).then(createContextMenus);
   }
-  // A sync-area change means the user saved provider settings on another machine
-  // (or this one — then the values are identical and the write is a no-op).
-  // Adopt them wholesale; local writes here don't loop back into this branch.
-  if (area === "sync" && ("providers" in changes || "defaultProvider" in changes)) {
-    const update = {};
-    if (changes.providers?.newValue)       update.providers       = changes.providers.newValue;
-    if (changes.defaultProvider?.newValue) update.defaultProvider = changes.defaultProvider.newValue;
-    if (Object.keys(update).length) chrome.storage.local.set(update);
+  // A sync-area change means the user saved settings on another machine (or this
+  // one — then the snapshot timestamp check inside makes the restore a no-op).
+  // Applying the snapshot writes promptData locally, which re-enters this
+  // function via the local branch above and rebuilds the context menus.
+  if (area === "sync" && "syncMeta" in changes) {
+    restoreOptionsFromSync();
   }
-}
-
-// ── Provider sync ─────────────────────────────────────────────────────────────
-// API keys and model choices are mirrored to chrome.storage.sync when saved on
-// the options page, so a signed-in browser profile carries them to the user's
-// other machines. chrome.storage.local stays the single source of truth that
-// the rest of the code reads; this only fills it from sync.
-
-// Copies synced provider tokens/models into local storage, but never overwrites
-// a provider that already has a token locally (conservative: runs at every
-// service worker startup, where local state may be newer than sync).
-function restoreProvidersFromSync() {
-  Promise.all([
-    chrome.storage.sync.get(["providers", "defaultProvider"]),
-    chrome.storage.local.get(["providers", "defaultProvider"]),
-  ]).then(([synced, local]) => {
-    if (!synced.providers) return;
-    const providers = local.providers || {};
-    // No local token anywhere = fresh install (or pre-1.73 upgrade); safe to also
-    // adopt the synced default provider, which install seeds to "openai".
-    const isFreshLocal = !Object.values(providers).some((p) => p?.token);
-    let changed = false;
-    for (const [key, cfg] of Object.entries(synced.providers)) {
-      if (!providers[key]?.token && (cfg.token || cfg.model)) {
-        providers[key] = cfg;
-        changed = true;
-      }
-    }
-    const update = {};
-    if (changed) update.providers = providers;
-    if (isFreshLocal && synced.defaultProvider && synced.defaultProvider !== local.defaultProvider) {
-      update.defaultProvider = synced.defaultProvider;
-    }
-    if (Object.keys(update).length) chrome.storage.local.set(update);
-  }).catch((err) => console.warn("lcgpt: could not restore settings from sync storage:", err));
 }
 
 // ── Migration helpers ─────────────────────────────────────────────────────────

--- a/background.js
+++ b/background.js
@@ -3,7 +3,8 @@
 if (typeof importScripts === "function") importScripts("defaults.js", "providers.js");
 
 chrome.storage.local.get(null).then(createContextMenus);
-chrome.storage.onChanged.addListener(handleLocalStorageChanges);
+chrome.storage.onChanged.addListener(handleStorageChanges);
+restoreProvidersFromSync();
 chrome.contextMenus.onClicked.addListener(handleContextMenuClicked);
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
@@ -35,7 +36,9 @@ chrome.runtime.onInstalled.addListener((details) => {
     makeDefaultPrompts().forEach(p => settings.promptData.push(p));
 
     settings.defaultPopupStyle = DEFAULT_POPUP_STYLE;
-    chrome.storage.local.set(settings);
+    // Restore synced provider keys AFTER the defaults are written, otherwise the
+    // empty providers object in `settings` would clobber a restore that ran first.
+    chrome.storage.local.set(settings).then(restoreProvidersFromSync);
   }
 });
 
@@ -55,8 +58,54 @@ function createContextMenus(result) {
   });
 }
 
-function handleLocalStorageChanges(changes) {
-  if ("promptData" in changes) chrome.storage.local.get(null).then(createContextMenus);
+function handleStorageChanges(changes, area) {
+  if (area === "local" && "promptData" in changes) {
+    chrome.storage.local.get(null).then(createContextMenus);
+  }
+  // A sync-area change means the user saved provider settings on another machine
+  // (or this one — then the values are identical and the write is a no-op).
+  // Adopt them wholesale; local writes here don't loop back into this branch.
+  if (area === "sync" && ("providers" in changes || "defaultProvider" in changes)) {
+    const update = {};
+    if (changes.providers?.newValue)       update.providers       = changes.providers.newValue;
+    if (changes.defaultProvider?.newValue) update.defaultProvider = changes.defaultProvider.newValue;
+    if (Object.keys(update).length) chrome.storage.local.set(update);
+  }
+}
+
+// ── Provider sync ─────────────────────────────────────────────────────────────
+// API keys and model choices are mirrored to chrome.storage.sync when saved on
+// the options page, so a signed-in browser profile carries them to the user's
+// other machines. chrome.storage.local stays the single source of truth that
+// the rest of the code reads; this only fills it from sync.
+
+// Copies synced provider tokens/models into local storage, but never overwrites
+// a provider that already has a token locally (conservative: runs at every
+// service worker startup, where local state may be newer than sync).
+function restoreProvidersFromSync() {
+  Promise.all([
+    chrome.storage.sync.get(["providers", "defaultProvider"]),
+    chrome.storage.local.get(["providers", "defaultProvider"]),
+  ]).then(([synced, local]) => {
+    if (!synced.providers) return;
+    const providers = local.providers || {};
+    // No local token anywhere = fresh install (or pre-1.73 upgrade); safe to also
+    // adopt the synced default provider, which install seeds to "openai".
+    const isFreshLocal = !Object.values(providers).some((p) => p?.token);
+    let changed = false;
+    for (const [key, cfg] of Object.entries(synced.providers)) {
+      if (!providers[key]?.token && (cfg.token || cfg.model)) {
+        providers[key] = cfg;
+        changed = true;
+      }
+    }
+    const update = {};
+    if (changed) update.providers = providers;
+    if (isFreshLocal && synced.defaultProvider && synced.defaultProvider !== local.defaultProvider) {
+      update.defaultProvider = synced.defaultProvider;
+    }
+    if (Object.keys(update).length) chrome.storage.local.set(update);
+  }).catch((err) => console.warn("lcgpt: could not restore settings from sync storage:", err));
 }
 
 // ── Migration helpers ─────────────────────────────────────────────────────────

--- a/defaults.js
+++ b/defaults.js
@@ -152,6 +152,71 @@ function makeDefaultPrompts() {
   return [whatIsThis, summarize];
 }
 
+// ── Settings sync ─────────────────────────────────────────────────────────────
+// The full Options object is mirrored to chrome.storage.sync on every save, so
+// a signed-in browser profile carries settings (prompts, CSS, API keys, …) to
+// the user's other machines. chrome.storage.local stays the single source of
+// truth that all other code reads; sync is only a transport.
+//
+// chrome.storage.sync allows ~8 KB per item, so the JSON is split into chunks:
+//   syncMeta          { savedAt, chunkCount }
+//   syncChunk_0..N-1  string pieces of JSON.stringify(options)
+// `syncSavedAt` in *local* storage records which snapshot this machine has
+// applied; a snapshot is only adopted when its savedAt is newer, so the most
+// recent Save on any machine wins.
+
+// 2000 UTF-16 units re-stringify to at most ~6 KB of UTF-8 (worst case 3 bytes
+// per unit; JSON escapes are 2 ASCII bytes), comfortably under the item quota.
+const SYNC_CHUNK_CHARS = 2000;
+
+function pushOptionsToSync(options) {
+  const json    = JSON.stringify(options);
+  const payload = {};
+  let chunkCount = 0;
+  for (let i = 0; i < json.length; i += SYNC_CHUNK_CHARS) {
+    payload[`syncChunk_${chunkCount++}`] = json.slice(i, i + SYNC_CHUNK_CHARS);
+  }
+  const savedAt = Date.now();
+  payload.syncMeta = { savedAt, chunkCount };
+
+  return chrome.storage.sync.get("syncMeta").then((old) =>
+    chrome.storage.sync.set(payload).then(() => {
+      // Remove chunks left over from a previously larger snapshot, so a stale
+      // tail can never be glued onto a shorter one.
+      const stale = [];
+      for (let i = chunkCount; i < (old.syncMeta?.chunkCount || 0); i++) stale.push(`syncChunk_${i}`);
+      return stale.length ? chrome.storage.sync.remove(stale) : undefined;
+    })
+  ).then(() => savedAt);
+}
+
+// Applies the synced snapshot to local storage if it is newer than what this
+// machine has already applied (or unconditionally with force, used on fresh
+// installs). Resolves to true when a snapshot was applied.
+function restoreOptionsFromSync({ force = false } = {}) {
+  return Promise.all([
+    chrome.storage.sync.get(null),
+    chrome.storage.local.get("syncSavedAt"),
+  ]).then(([synced, local]) => {
+    const meta = synced.syncMeta;
+    if (!meta?.chunkCount) return false;
+    if (!force && meta.savedAt <= (local.syncSavedAt || 0)) return false;
+    let json = "";
+    for (let i = 0; i < meta.chunkCount; i++) {
+      const piece = synced[`syncChunk_${i}`];
+      if (typeof piece !== "string") return false; // partially propagated — retry on next sync event
+      json += piece;
+    }
+    const options = JSON.parse(json); // corrupt data throws into the catch below
+    return chrome.storage.local
+      .set({ ...options, syncSavedAt: meta.savedAt })
+      .then(() => true);
+  }).catch((err) => {
+    console.warn("lcgpt: could not restore settings from sync storage:", err);
+    return false;
+  });
+}
+
 // ── Data classes ──────────────────────────────────────────────────────────────
 
 class StoredPrompt {

--- a/defaults.js
+++ b/defaults.js
@@ -1,5 +1,22 @@
 // ── Visual defaults ───────────────────────────────────────────────────────────
 
+// The follow-up question box styles live in their own constant because CSS
+// migration needs them separately: CSS stored by pre-1.73 versions predates the
+// question box, and without these rules the box renders as an invisible
+// zero-height div. migrateCSSClassNames() appends this block to legacy CSS.
+const DEFAULT_QUESTION_STYLE = `.lcgpt-question {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 1.4em;
+  margin-top: 6px;
+  padding: 2px 4px;
+  border: 1px solid #ccc;
+  outline: none;
+  background: #fff;
+  color: #000;
+}`;
+
 const DEFAULT_POPUP_STYLE = `:host {
   display: block;
   position: fixed;
@@ -53,18 +70,7 @@ const DEFAULT_POPUP_STYLE = `:host {
 .lcgpt-message {
   white-space: pre-wrap;
 }
-.lcgpt-question {
-  display: block;
-  box-sizing: border-box;
-  width: 100%;
-  min-height: 1.4em;
-  margin-top: 6px;
-  padding: 2px 4px;
-  border: 1px solid #ccc;
-  outline: none;
-  background: #fff;
-  color: #000;
-}`;
+${DEFAULT_QUESTION_STYLE}`;
 
 const DEFAULT_SELECTED_TEXT_PROMPT_CONTENT = "I'll input a word or sentence or a symbol in next message taken from webpage (page title: VAR_PAGE_TITLE page URL: VAR_PAGE_URL). If it is a name of something or someone give some info about that while being terse. If it's a non-english text, just translate it to English. Otherwise just explain what it means.";
 const DEFAULT_SELECTED_TEXT_PROMPT_TITLE   = "What's this?";
@@ -86,7 +92,8 @@ $ = (id) => document.getElementById(id);
 // and options.js so the migration happens at every load path.
 function migrateCSSClassNames(css) {
   if (!css) return css;
-  if (css.includes("lookupchatgpt")) {
+  const isLegacy = css.includes("lookupchatgpt");
+  if (isLegacy) {
     css = css
       // Oldest names: lookupchatgpt-popup-* (before the "result-dialog" rename)
       .replace(/#lookupchatgpt-popup-container\b/g,         "#lcgpt-result-container")
@@ -101,7 +108,14 @@ function migrateCSSClassNames(css) {
       .replace(/\.lookupchatgpt-button-container\b/g,       ".lcgpt-button-container");
   }
   // Migrate from regular DOM selector to shadow DOM :host selector
-  return css.replace(/#lcgpt-result-container\b/g, ":host");
+  css = css.replace(/#lcgpt-result-container\b/g, ":host");
+  // Legacy CSS predates the follow-up question box; without these rules the box
+  // renders as an invisible zero-height div. Only heal CSS that was actually
+  // migrated — CSS already in the current format is the user's own business.
+  if (isLegacy && !css.includes(".lcgpt-question")) {
+    css += "\n" + DEFAULT_QUESTION_STYLE;
+  }
+  return css;
 }
 
 // Normalises a StoredPrompt loaded from storage, handling fields added or renamed

--- a/options.js
+++ b/options.js
@@ -143,6 +143,13 @@ function saveOptions() {
     // `token` would otherwise linger and get re-migrated into providers.openai.token
     // on every load — resurrecting the key even after the user deliberately clears it.
     chrome.storage.local.remove(["token", "extButtonPrompt"]);
+    // Mirror provider keys/models to chrome.storage.sync so a signed-in browser
+    // profile carries them to the user's other machines (background.js restores
+    // them into local storage on the other side). Failure is non-fatal — sync
+    // storage is unavailable e.g. in Firefox temporary installs.
+    chrome.storage.sync
+      .set({ providers: opts.providers, defaultProvider: opts.defaultProvider })
+      .catch((err) => console.warn("lcgpt: could not mirror settings to sync storage:", err));
     // Briefly flash the save button to confirm
     const btn = $("savePrompts");
     btn.textContent = "Saved ✓";

--- a/options.js
+++ b/options.js
@@ -143,12 +143,13 @@ function saveOptions() {
     // `token` would otherwise linger and get re-migrated into providers.openai.token
     // on every load — resurrecting the key even after the user deliberately clears it.
     chrome.storage.local.remove(["token", "extButtonPrompt"]);
-    // Mirror provider keys/models to chrome.storage.sync so a signed-in browser
-    // profile carries them to the user's other machines (background.js restores
-    // them into local storage on the other side). Failure is non-fatal — sync
-    // storage is unavailable e.g. in Firefox temporary installs.
-    chrome.storage.sync
-      .set({ providers: opts.providers, defaultProvider: opts.defaultProvider })
+    // Mirror everything to chrome.storage.sync so a signed-in browser profile
+    // carries the full setup — prompts, CSS, API keys — to the user's other
+    // machines (background.js applies it on the other side). Failure is
+    // non-fatal: sync may be over quota or unavailable (e.g. Firefox temporary
+    // installs); local storage remains the source of truth either way.
+    pushOptionsToSync(opts)
+      .then((savedAt) => chrome.storage.local.set({ syncSavedAt: savedAt }))
       .catch((err) => console.warn("lcgpt: could not mirror settings to sync storage:", err));
     // Briefly flash the save button to confirm
     const btn = $("savePrompts");


### PR DESCRIPTION
## Summary
This PR implements cross-device settings synchronization for the extension, allowing users to sync their prompts, CSS customizations, and API keys across multiple machines when signed into their Chrome profile.

## Key Changes

- **Extracted question box styles**: Moved `.lcgpt-question` CSS rules into a separate `DEFAULT_QUESTION_STYLE` constant to enable reuse in CSS migration logic
- **Enhanced CSS migration**: Updated `migrateCSSClassNames()` to append question box styles to legacy CSS that predates the follow-up question feature, preventing invisible zero-height divs
- **Implemented settings sync infrastructure**: Added two new functions in `defaults.js`:
  - `pushOptionsToSync()`: Chunks the full Options object into ~2KB pieces and writes to `chrome.storage.sync` with metadata tracking
  - `restoreOptionsFromSync()`: Retrieves synced snapshots from other machines and applies them to local storage if newer
- **Updated background service worker**: 
  - Renamed `handleLocalStorageChanges()` to `handleStorageChanges()` to handle both local and sync storage events
  - Added sync restoration on service worker startup to catch snapshots that arrived while asleep
  - Modified install handler to adopt synced settings from other machines instead of seeding defaults
- **Integrated sync into options save flow**: `saveOptions()` now mirrors all settings to sync storage after local save, with graceful error handling

## Implementation Details

- Sync uses a chunking strategy with `SYNC_CHUNK_CHARS = 2000` to stay under Chrome's 8KB per-item quota
- Snapshots include a `savedAt` timestamp; the most recent snapshot wins across all machines
- `syncSavedAt` in local storage tracks which snapshot has been applied, preventing duplicate restores
- Stale chunks from previously larger snapshots are cleaned up to prevent corruption
- Sync failures are non-fatal; local storage remains the authoritative source of truth
- Fresh installs check for synced settings before seeding defaults, providing seamless multi-device setup

https://claude.ai/code/session_01CoLnEJEBASEPDtktTNg3J8