### PR TITLE
Release 2.0.1: bump manifests, match this repo's tag convention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,10 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # This repo tags bare version numbers (1.2, 1.7, 2.0), so match those.
+      # The v-prefixed form is accepted too in case you switch conventions.
+      - '[0-9]+.[0-9]+*'
+      - 'v[0-9]+.[0-9]+*'
   workflow_dispatch:
 
 permissions:
@@ -41,9 +44,9 @@ jobs:
       # A tag that disagrees with the manifest would ship the wrong version
       # number to the stores, so refuse rather than guess which one is right.
       - name: Check tag matches manifest version
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          tag="${GITHUB_REF_NAME#v}"
+          tag="${GITHUB_REF_NAME#v}"   # tolerate an optional leading v
           manifest="${{ steps.meta.outputs.version }}"
           if [ "$tag" != "$manifest" ]; then
             echo "::error::Tag $GITHUB_REF_NAME implies version $tag but manifest.json says $manifest."
@@ -60,10 +63,10 @@ jobs:
           if-no-files-found: error
 
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "$GITHUB_REF_NAME" dist/*.zip \
-            --title "v${{ steps.meta.outputs.version }}" \
+            --title "$GITHUB_REF_NAME" \
             --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ preview_panel.html
 dist/
 chrome_ext.zip
 firefox_ext.zip
+__pycache__/

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Lookup selected text via ChatGPT",
-  "version": "1.73",
+  "version": "2.0.1",
   "description": "Look up selected text using ChatGPT using your own prompts and show the results on the same page",
   "permissions": ["activeTab", "contextMenus", "storage", "scripting"],
   "host_permissions": [

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Lookup selected text via ChatGPT",
-  "version": "1.73",
+  "version": "2.0.1",
   "description": "Look up selected text using ChatGPT using your own prompts and show the results on the same page",
   "permissions": ["activeTab", "contextMenus", "storage"],
   "host_permissions": [

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -100,6 +100,32 @@ def collect(manifest_name):
     return manifest, files
 
 
+def version_problems(version):
+    """Check a version against Chrome's manifest rules.
+
+    One to four dot-separated integers, each 0-65535, and a non-zero component
+    may not have a leading zero -- so "2.01" is rejected even though it looks
+    fine. Catching it here beats having the Web Store reject the upload.
+    """
+    text = str(version or "")
+    if not text:
+        return ["version is missing"]
+    parts = text.split(".")
+    if not 1 <= len(parts) <= 4:
+        return [f"version {text!r} must have 1-4 dot-separated parts, found {len(parts)}"]
+    problems = []
+    for part in parts:
+        if not part.isdigit():
+            problems.append(f"version {text!r}: part {part!r} is not a non-negative integer")
+        elif len(part) > 1 and part[0] == "0":
+            problems.append(
+                f"version {text!r}: part {part!r} has a leading zero; Chrome rejects this "
+                f"(use {str(int(part))!r}, or move it to its own component)")
+        elif int(part) > 65535:
+            problems.append(f"version {text!r}: part {part!r} exceeds the maximum of 65535")
+    return problems
+
+
 def validate():
     """Check both manifests parse, agree on version, and reference real files."""
     problems, version = [], None
@@ -114,8 +140,8 @@ def validate():
             continue
 
         this_version = manifest.get("version")
-        if not re.fullmatch(r"\d+(\.\d+){0,3}", str(this_version or "")):
-            problems.append(f"{name}: version {this_version!r} is not 1-4 dot-separated integers")
+        for complaint in version_problems(this_version):
+            problems.append(f"{name}: {complaint}")
         if version is None:
             version = this_version
         elif this_version != version:


### PR DESCRIPTION
Version goes to 2.0.1 in both manifests. Note this is not the 2.01 that was asked for: Chrome allows 1-4 dot-separated integers where a non-zero component may not carry a leading zero, so "2.01" is rejected at upload. 2.0.1 is the nearest valid reading given the existing 2.0 tag.

The release workflow triggered only on v* tags, but this repo tags bare version numbers (1.2, 1.7, 2.0). That mismatch is why the existing 2.0 tag produced no release. Tag filters now accept both bare and v-prefixed forms, the tag/version guard and release step no longer require the v prefix, and the release title follows the tag rather than hard-coding one.

scripts/package.py now applies Chrome's real version rules instead of a loose digits-and-dots check: it rejects leading zeros, components above 65535, and more than four components, so this class of mistake fails locally rather than at the store.


Claude-Session: https://claude.ai/code/session_01CoLnEJEBASEPDtktTNg3J8