### PR TITLE
Make the release step work when the tag is created from the GitHub UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,21 @@ jobs:
           path: dist/*.zip
           if-no-files-found: error
 
-      - name: Create GitHub Release
+      # Handles both ways of tagging:
+      #   - `git push origin <tag>`  -> no Release exists yet, so create one.
+      #   - Releases UI "Draft a new release" -> tagging and the Release happen
+      #     together, so the Release already exists and we just attach the ZIPs.
+      - name: Publish GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" dist/*.zip \
-            --title "$GITHUB_REF_NAME" \
-            --generate-notes
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; attaching ZIPs."
+            gh release upload "$GITHUB_REF_NAME" dist/*.zip --clobber
+          else
+            echo "Creating release $GITHUB_REF_NAME."
+            gh release create "$GITHUB_REF_NAME" dist/*.zip \
+              --title "$GITHUB_REF_NAME" \
+              --generate-notes
+          fi


### PR DESCRIPTION
GitHub has no plain "create a tag" control; the only web UI that makes one is Releases -> Draft a new release, which creates the tag and the Release in the same action. The workflow then ran gh release create against a Release that already existed and failed, so tagging from the browser could not work.

The step now checks for an existing Release and attaches the ZIPs to it, falling back to creating one. That covers both routes: pushing a tag with git leaves no Release to find and one is created, while the UI route finds the Release the user just published and uploads the assets to it.


Claude-Session: https://claude.ai/code/session_01CoLnEJEBASEPDtktTNg3J8